### PR TITLE
Microsoft Azure Event Grid utils

### DIFF
--- a/houston/plugin/azure.py
+++ b/houston/plugin/azure.py
@@ -1,0 +1,78 @@
+"""Houston Utilities for Microsoft Azure
+
+Recommended usage:
+
+    # end stage and trigger downstream stages
+
+    res = h.end_stage(stage)
+
+    for next_stage in res['next']:
+
+        topic = (your method of getting the topic for the 'next_stage',
+                 e.g. stage_parameter, simple conversion function, hard coded map, etc.)
+
+        topic_key = (your method of getting the topic key for the 'next_stage',
+                     e.g. environment variable, key vault secret, load from text file, etc.)
+
+        h.event_grid_trigger({"stage": next_stage, "mission_id": mission_id}, topic, topic_key)
+
+"""
+
+from houston.client import Houston
+from datetime import datetime, timezone
+from azure.eventgrid import EventGridClient
+from msrest.authentication import TopicCredentials
+from msrest.exceptions import HttpOperationError
+import uuid
+import time
+
+
+class AzureHouston(Houston):
+
+    def event_grid_trigger(self, data, topic, topic_key, retry=3):
+        """Sends a message to the provided Event Grid topic with the provided data payload.
+
+        :param dict data: content of the message to be sent. Should contain 'stage' and 'mission_id'. Can contain any
+                          additional JSON serializable information.
+        :param string topic: The host name of the topic, e.g. 'topic1.westus2-1.eventgrid.azure.net'
+        :param string topic_key: A 44 character access key for the topic.
+        """
+        if 'plan' not in data:
+            data['plan'] = self.plan['name']
+
+        try:
+            publish_event_grid_event(data, topic, topic_key)
+
+        except HttpOperationError as e:
+            # retry for azure errors
+            if e.response.status_code >= 500:
+                if retry > 0:
+                    time.sleep(0.5)
+                    self.event_grid_trigger(data, topic, topic_key, retry - 1)
+            else:
+                raise e
+
+
+def publish_event_grid_event(data, topic_hostname, topic_key):
+    """Sends a message to the provided Event Grid topic with the provided data payload.
+    :param dict data: content of the message to be sent.
+    :param string topic_hostname: The host name of the topic, e.g. 'topic1.westus2-1.eventgrid.azure.net'
+    :param string topic_key: A 44 character access key for the topic.
+    """
+    credentials = TopicCredentials(topic_key)
+
+    event_grid_client = EventGridClient(credentials)
+
+    event_id = str(uuid.uuid4())
+
+    event_grid_client.publish_events(
+        topic_hostname,
+        events=[{
+            'id': event_id,
+            'subject': "Houston Stage Trigger",
+            'data': data,
+            'event_type': 'HoustonStageTrigger',
+            'event_time': datetime.now(timezone.utc),
+            'data_version': 1
+        }]
+    )

--- a/houston/plugin/gcp.py
+++ b/houston/plugin/gcp.py
@@ -1,23 +1,28 @@
 """Houston Utilities for Google Cloud Platform
 
 PubSub utils:
-Allows user to create subscriber/publish message according to the plan stage options, e.g.:
+Allows user to create Google Cloud Pub/Sub message according to the plan stage options, e.g.:
 
-    res = h.end_stage("load-data", id)
-    next_stage = res["next"]
-    h.gcp.trigger(next_stage, id)
+    h.project = "my-project-1234"  # set the Google Cloud project name in the client
 
---> finds the topic it needs to use for the next_task from the stage parameters in the plan statement
---> sends a pub/sub message to the next task's topic
+    res = h.end_stage("load-data", mission_id)
+
+    for next_stage in res['next']:
+
+        h.pubsub_trigger({'stage': next_stage, 'mission_id': mission_id}, topic=h.get_params(next_stage)['topic'])
+
+--> sends a Pub/Sub message to the next tasks' topics. This assumes we have given each stage a 'topic' parameter.
+
+Note: The topic name can either be provided as an argument or can be set as a parameter for the stage as 'topic' or
+'psq', in which case it will be found automatically.
 
 or:
 
-    h.gcp.project = "my-project-1234"
-    h.gcp.topic = "ps-topic-next-stage"
+    h.project = "my-project-1234"  # set the Google Cloud project name in the client
 
-    res = h.end_stage("load-data", id)
-    next_stage = res["next"]
-    h.gcp.trigger_stage_via_pubsub(next_stage, id)
+    response = h.end_stage("load-data", mission_id)
+
+    h.call_stage_via_pubsub(response, mission_id)  # assumes each stage has a 'psq' parameter which gives the topic name
 
 """
 
@@ -33,6 +38,46 @@ class GCPHouston(Houston):
     project = os.getenv("GCP_PROJECT", None)
     topic = None
 
+    def pubsub_trigger(self, data, topic=None):
+        """Sends a message to the provided Pub/Sub topic with the provided data payload.
+
+        :param dict data: content of the message to be sent. Should contain 'stage' and 'mission_id'. Can contain any
+                          additional JSON serializable information.
+        :param string topic: Google Pub/Sub topic name, e.g. 'topic-for-stage'. This can either be provided here or be
+                             set as a parameter for the stage as 'topic' or 'psq'.
+        """
+
+        publisher_client = pubsub_v1.PublisherClient()
+        if self.project is None:
+            raise ValueError(
+                "Project is not set. Use GCPHouston.project = '[PROJECT]' "
+                "or set 'GCP_PROJECT' environment variable"
+            )
+
+        if 'plan' not in data:
+            data['plan'] = self.plan['name']
+
+        # try to find the topic name in the stage parameters
+        if topic is None:
+            if 'stage' in data:
+                stage_params = self.get_params(data['stage'])
+                if stage_params:
+                    if stage_params['topic']:
+                        topic = stage_params['topic']
+                    elif stage_params['psq']:
+                        topic = stage_params['psq']
+
+            if topic is None:
+                raise ValueError("Pub/Sub could not be determined. It can either be provided as an argument to "
+                                 "pubsub_trigger, or be a stage parameter with name 'topic' or 'psq'")
+
+        full_topic = "projects/{project}/topics/{topic}".format(
+            project=self.project, topic=topic
+        )
+
+        future = publisher_client.publish(topic=full_topic, data=json.dumps(data).encode("utf-8"))
+        future.result()
+
     def call_stage_via_pubsub(self, response, mission_id):
         """Send stage details to Google Cloud Platform PubSub. Sends stage, mission_id, plan name as json in message
            body, parameters as attributes
@@ -42,7 +87,8 @@ class GCPHouston(Houston):
 
            Blocks until PubSub message has been sent
 
-        :param dict response: Response from Houston.end_stage
+        :param dict response: response from Houston.end_stage
+        :param string mission_id: unique identifier of mission currently being completed
         """
 
         publisher_client = pubsub_v1.PublisherClient()
@@ -61,7 +107,7 @@ class GCPHouston(Houston):
                     )
                 )
                 continue
-            if "psq" not in response["params"][next_task].keys():
+            if "psq" not in response["params"][next_task].keys() and "topic" not in response["params"][next_task].keys():
                 print(
                     "task: {next_task} does not have psq topic set, skipping".format(
                         next_task=next_task
@@ -70,7 +116,10 @@ class GCPHouston(Houston):
                 continue
 
             task_parameters = response["params"][next_task]
-            target_psq = task_parameters.pop("psq")
+            if "psq" in task_parameters:
+                target_psq = task_parameters.pop("psq")
+            else:
+                target_psq = task_parameters.pop("topic")
 
             data = json.dumps(
                 {"stage": next_task, "mission_id": mission_id, "plan": self.plan}

--- a/tests/test_azure.py
+++ b/tests/test_azure.py
@@ -1,0 +1,56 @@
+import time
+import unittest
+import sys
+
+if sys.version_info >= (3, 3):
+    from unittest import mock
+else:
+    import mock
+from houston.plugin.azure import AzureHouston
+from tests.test_houston import MockResponse
+
+
+class MockEventGridResponse:
+    @staticmethod
+    def publish_events(topic, events):
+        return None
+
+
+class TestEventGrid(unittest.TestCase):
+
+    test_plan_description = {
+        "name": "test",
+        "stages": [
+            {"name": "start", "downstream": ["end"], "params": {"table": "test.sql"}},
+            {"name": "end", "params": {"table": "test.sql", "topic": "tp-test-end", "topic_key": "abc"}},  # note: it is not recommeneded to keep keys in stage params
+        ],
+    }
+
+    def test_event_grid_trigger(self):
+        with mock.patch(
+            "houston.plugin.azure.EventGridClient"
+        ) as event_grid_client:
+            with mock.patch("houston.interface.requests.request") as http:
+                http.return_value = MockResponse(
+                    status_code=200,
+                    json_data={
+                        "success": True,
+                        "complete": False,
+                        "next": ["end"],
+                        "params": {"end": {"table": "test.sql", "psq": "tp-test-end"}},
+                    },
+                )
+                houston = AzureHouston(
+                    api_key="test-key", plan=self.test_plan_description
+                )
+                response = houston.end_stage("start", "test-launch-id")
+                event_grid_client.return_value = MockEventGridResponse
+
+                for next_stage in response['next']:
+                    params = houston.get_params(next_stage)
+                    houston.event_grid_trigger({'stage': next_stage, 'mission_id': "test-launch-id"},
+                                               topic=params['topic'], topic_key=params['topic_key'])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_houston.py
+++ b/tests/test_houston.py
@@ -88,6 +88,16 @@ class TestStage(unittest.TestCase):
             houston = Houston(api_key="test", plan=self.test_plan_description)
             houston.start_stage("test", "launch-id")
 
+    def test_get_params(self):
+        houston = Houston(api_key="test", plan=self.test_plan_description)
+
+        params = houston.get_params("start")
+        self.assertEqual(params['table'], "test.sql")
+        self.assertIs(params['notaparam'], None)
+
+        not_params = houston.get_params("notastage")
+        self.assertIs(not_params, None)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
- new AzureHouston client class
- event_grid_trigger method for azure client
- pubsub_trigger method for gcp client to match the event grid implementation 
- fail_stage method
- ignore_stage method
- get_params method
- more unit tests for all new functionality 